### PR TITLE
Use the new navigation methods

### DIFF
--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -31,6 +31,10 @@ def ChoiceEntryComponent(key=None, text=None):
 				png = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "buttons/key_%s.png" % key))
 			if png:
 				x, y, w, h = parameters.get("ChoicelistIcon", (5, 0, 35, 25))
+				if key == "verticalline" and "ChoicelistIconVerticalline" in parameters:
+					x, y, w, h = parameters.get("ChoicelistIconVerticalline", (5, 0, 35, 25))
+				if key == "expanded" and "ChoicelistIconExpanded" in parameters:
+					x, y, w, h = parameters.get("ChoicelistIconExpanded", (5, 0, 35, 25))
 				res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, x, y, w, h, png))
 		else:
 			x, y, w, h = parameters.get("ChoicelistNameSingle", (5, 0, 800, 25))

--- a/lib/python/Components/ChoiceList.py
+++ b/lib/python/Components/ChoiceList.py
@@ -31,10 +31,6 @@ def ChoiceEntryComponent(key=None, text=None):
 				png = LoadPixmap(resolveFilename(SCOPE_GUISKIN, "buttons/key_%s.png" % key))
 			if png:
 				x, y, w, h = parameters.get("ChoicelistIcon", (5, 0, 35, 25))
-				if key == "verticalline" and "ChoicelistIconVerticalline" in parameters:
-					x, y, w, h = parameters.get("ChoicelistIconVerticalline", (5, 0, 35, 25))
-				if key == "expanded" and "ChoicelistIconExpanded" in parameters:
-					x, y, w, h = parameters.get("ChoicelistIconExpanded", (5, 0, 35, 25))
 				res.append((eListboxPythonMultiContent.TYPE_PIXMAP_ALPHABLEND, x, y, w, h, png))
 		else:
 			x, y, w, h = parameters.get("ChoicelistNameSingle", (5, 0, 800, 25))
@@ -48,8 +44,12 @@ class ChoiceList(MenuList):
 		font = fonts.get("ChoiceList", ("Regular", 20, 30))
 		self.l.setFont(0, gFont(font[0], font[1]))
 		self.l.setItemHeight(font[2])
+		self.itemHeight = font[2]
 		self.selection = selection
 
 	def postWidgetCreate(self, instance):
 		MenuList.postWidgetCreate(self, instance)
 		self.moveToIndex(self.selection)
+
+	def getItemHeight(self):
+		return self.itemHeight

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -202,7 +202,7 @@ class ConfigListScreen:
 			"pageDown": (self.keyPageDown, _("Move down a screen")),
 			"bottom": (self.keyBottom, _("Move to last line / screen"))
 		}, prio=1, description=_("Common Setup Actions"))
-		self["menuConfigActions"] = HelpableActionMap(self, ["ConfigListActions"], {
+		self["menuConfigActions"] = HelpableActionMap(self, "ConfigListActions", {
 			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
 		}, prio=1, description=_("Common Setup Actions"))
 		self["menuConfigActions"].setEnabled(False if fullUI else True)
@@ -227,7 +227,7 @@ class ConfigListScreen:
 			"toggleOverwrite": (self.keyToggle, _("Toggle new text inserts before or overwrites existing text")),
 		}, prio=1, description=_("Common Setup Actions"))
 		self["editConfigActions"].setEnabled(False if fullUI else True)
-		self["virtualKeyBoardActions"] = HelpableActionMap(self, ["VirtualKeyboardActions"], {
+		self["virtualKeyBoardActions"] = HelpableActionMap(self, "VirtualKeyboardActions", {
 			"showVirtualKeyboard": (self.keyText, _("Display the virtual keyboard for data entry"))
 		}, prio=1, description=_("Common Setup Actions"))
 		self["virtualKeyBoardActions"].setEnabled(False)

--- a/lib/python/Components/MenuList.py
+++ b/lib/python/Components/MenuList.py
@@ -4,17 +4,14 @@ from Components.GUIComponent import GUIComponent
 
 
 class MenuList(GUIComponent):
-	def __init__(self, list, enableWrapAround=True, content=eListboxPythonStringContent):  # enableWrapAround is deprecated as this is now controllable in the skin and windowstyle.
+	GUI_WIDGET = eListbox
+
+	def __init__(self, list, enableWrapAround=None, content=eListboxPythonStringContent):  # enableWrapAround is deprecated as this is now controllable in the skin and windowstyle.
 		GUIComponent.__init__(self)
 		self.list = list
 		self.l = content()
 		self.l.setList(self.list)
 		self.onSelectionChanged = []
-
-	def getCurrent(self):
-		return self.l.getCurrentSelection()
-
-	GUI_WIDGET = eListbox
 
 	def postWidgetCreate(self, instance):
 		instance.setContent(self.l)
@@ -25,14 +22,8 @@ class MenuList(GUIComponent):
 		instance.selectionChanged.get().remove(self.selectionChanged)
 
 	def selectionChanged(self):
-		for module in self.onSelectionChanged:
-			module()
-
-	def getSelectionIndex(self):
-		return self.l.getCurrentSelectionIndex()
-
-	def getSelectedIndex(self):
-		return self.l.getCurrentSelectionIndex()
+		for callback in self.onSelectionChanged:
+			callback()
 
 	def getList(self):
 		return self.list
@@ -41,37 +32,66 @@ class MenuList(GUIComponent):
 		self.list = list
 		self.l.setList(self.list)
 
-	def moveToIndex(self, index):
-		if self.instance is not None:
-			self.instance.moveSelectionTo(index)
+	def selectionEnabled(self, enabled):
+		if self.instance:
+			self.instance.setSelectionEnable(enabled)
+
+	def getCurrent(self):
+		return self.l.getCurrentSelection()
+
+	def getSelectionIndex(self):
+		return self.l.getCurrentSelectionIndex()
+
+	def getSelectedIndex(self):
+		return self.l.getCurrentSelectionIndex()
 
 	def count(self):
 		return len(self.list)
 
+	def moveToIndex(self, index):
+		if self.instance:
+			self.instance.moveSelectionTo(index)
+
+	def goTop(self):
+		if self.instance:
+			self.instance.goTop()
+
+	def goPageUp(self):
+		if self.instance:
+			self.instance.goPageUp()
+
+	def goLineUp(self):
+		if self.instance:
+			self.instance.goLineUp()
+
+	def goLineDown(self):
+		if self.instance:
+			self.instance.goLineDown()
+
+	def goPageDown(self):
+		if self.instance:
+			self.instance.goPageDown()
+
+	def goBottom(self):
+		if self.instance:
+			self.instance.goBottom()
+
+	# Old navigation method names.
+	#
 	def top(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveTop)
+		self.goTop()
 
 	def pageUp(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.pageUp)
+		self.goPageUp()
 
 	def up(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveUp)
+		self.goLineUp()
 
 	def down(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveDown)
+		self.goLineDown()
 
 	def pageDown(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.pageDown)
+		self.goPageDown()
 
 	def bottom(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveEnd)
-
-	def selectionEnabled(self, enabled):
-		if self.instance is not None:
-			self.instance.setSelectionEnable(enabled)
+		self.goBottom()

--- a/lib/python/Components/Sources/List.py
+++ b/lib/python/Components/Sources/List.py
@@ -11,48 +11,50 @@ setup the "fonts".
 This has been done so another converter could convert the list to a different format, for example
 to generate HTML."""
 
-	def __init__(self, list=[], enableWrapAround=False, item_height=25, fonts=[]):
+	# NOTE: The calling arguments enableWraparound, item_height and fonts are not
+	# used but remain here so that calling code does not need to be modified.
+	# The enableWrapAround function is correctly handles by the C++ code and the
+	# use of the enableWrapAround="1" attribute in the skin. Similarly the
+	# itemHeight and font specifications are handled by the skin.
+	#
+	def __init__(self, list=[], enableWrapAround=None, item_height=0, fonts=[]):
 		Source.__init__(self)
-		self.__list = list
-		self.enableWrapAround = enableWrapAround
-		self.item_height = item_height
-		self.fonts = fonts
+		self.listData = list
+		self.listStyle = "default"  # Style might be an optional string which can be used to define different visualizations in the skin.
 		self.onSelectionChanged = []
-		self.disable_callbacks = False
-		self.__style = "default"  # Style might be an optional string which can be used to define different visualisations in the skin.
+		self.disableCallbacks = False
 
-	def setList(self, list):
-		self.__list = list
+	def setList(self, listData):
+		self.listData = listData
 		self.changed((self.CHANGED_ALL,))
 
-	list = property(lambda self: self.__list, setList)
+	list = property(lambda self: self.listData, setList)
 
-	def updateList(self, list):
+	def updateList(self, listData):
 		"""Changes the list without changing the selection or emitting changed Events"""
-		maxIndex = len(list) - 1
-		oldIndex = self.index
-		self.disable_callbacks = True
-		self.list = list
+		maxIndex = len(listData) - 1
+		oldIndex = min(self.index, maxIndex)
+		self.disableCallbacks = True
+		self.setList(listData)
 		self.index = oldIndex
-		self.disable_callbacks = False
+		self.disableCallbacks = False
 
 	def entry_changed(self, index):
-		if not self.disable_callbacks:
+		if not self.disableCallbacks:
 			self.downstream_elements.entry_changed(index)
 
 	def modifyEntry(self, index, data):
-		self.__list[index] = data
+		self.listData[index] = data
 		self.entry_changed(index)
 
 	def selectionChanged(self, index):
-		if self.disable_callbacks:
+		if self.disableCallbacks:
 			return
-		# Update all non-master targets.
-		for x in self.downstream_elements:
-			if x is not self.master:
-				x.index = index
-		for x in self.onSelectionChanged:
-			x()
+		for element in self.downstream_elements:  # Update all non-master targets.
+			if element is not self.master:
+				element.index = index
+		for callback in self.onSelectionChanged:
+			callback()
 
 	@cached
 	def getCurrent(self):
@@ -62,7 +64,7 @@ to generate HTML."""
 
 	@cached
 	def getIndex(self):
-		return self.master.index if self.master is not None else None
+		return self.master.index if self.master is not None else 0  # None - The 0 is a hack to avoid badly written code from crashing!
 
 	def setIndex(self, index):
 		if self.master is not None:
@@ -75,11 +77,11 @@ to generate HTML."""
 
 	@cached
 	def getStyle(self):
-		return self.__style
+		return self.listStyle
 
 	def setStyle(self, style):
-		if self.__style != style:
-			self.__style = style
+		if self.listStyle != style:
+			self.listStyle = style
 			self.changed((self.CHANGED_SPECIFIC, "style"))
 
 	style = property(getStyle, setStyle)
@@ -88,52 +90,74 @@ to generate HTML."""
 		return self.getIndex()
 
 	def count(self):
-		return len(self.__list)
+		return len(self.listData)
 
+	def goTop(self):
+		try:
+			instance = self.master.master.instance
+			instance.goTop()
+		except AttributeError:
+			return
+
+	def goPageUp(self):
+		try:
+			instance = self.master.master.instance
+			instance.goPageUp()
+		except AttributeError:
+			return
+
+	def goLineUp(self):
+		try:
+			instance = self.master.master.instance
+			instance.goLineUp()
+		except AttributeError:
+			return
+
+	def goLineDown(self):
+		try:
+			instance = self.master.master.instance
+			instance.goLineDown()
+		except AttributeError:
+			return
+
+	def goPageDown(self):
+		try:
+			instance = self.master.master.instance
+			instance.goPageDown()
+		except AttributeError:
+			return
+
+	def goBottom(self):
+		try:
+			instance = self.master.master.instance
+			instance.goBottom()
+		except AttributeError:
+			return
+
+	# These hacks protect code that was modified to use the previous up/down hack!
+	#
 	def selectPrevious(self):
-		if self.getIndex() > 0:
-			self.index -= 1
-		elif self.enableWrapAround:
-			self.index = self.count() - 1
-		self.setIndex(self.index)
+		self.goLineUp()
 
 	def selectNext(self):
-		if self.getIndex() < self.count() - 1:
-			self.index += 1
-		elif self.enableWrapAround:
-			self.index = 0
-		self.setIndex(self.index)
+		self.goLineDown()
 
+	# Old navigation method names.
+	#
 	def top(self):
-		try:
-			instance = self.master.master.instance
-			instance.moveSelection(instance.moveTop)
-		except AttributeError:
-			return
+		self.goTop()
 
 	def pageUp(self):
-		try:
-			instance = self.master.master.instance
-			instance.moveSelection(instance.pageUp)
-		except AttributeError:
-			return
+		self.goPageUp()
 
 	def up(self):
-		self.selectPrevious()
+		self.goLineUp()
 
 	def down(self):
-		self.selectNext()
+		self.goLineDown()
 
 	def pageDown(self):
-		try:
-			instance = self.master.master.instance
-			instance.moveSelection(instance.pageDown)
-		except AttributeError:
-			return
+		self.goPageDown()
 
 	def bottom(self):
-		try:
-			instance = self.master.master.instance
-			instance.moveSelection(instance.moveEnd)
-		except AttributeError:
-			return
+		self.goBottom()


### PR DESCRIPTION
- Use the new navigation methods in the C++ code.
- Keep the old navigation methods as pointers to the new methods until the clean up is completed.
- Improve some variable names to eliminate PEP8 errors.
- Small code move to make the code more readable.

Co-authored-by: IanSav <is.ozpvr@gmail.com>